### PR TITLE
Reordered the modifiers to comply with the Java Language Specification

### DIFF
--- a/robocode.api/src/main/java/robocode/ScannedRobotEvent.java
+++ b/robocode.api/src/main/java/robocode/ScannedRobotEvent.java
@@ -32,7 +32,7 @@ import java.nio.ByteBuffer;
  */
 public class ScannedRobotEvent extends Event {
 	private static final long serialVersionUID = 1L;
-	private final static int DEFAULT_PRIORITY = 10;
+	private static final int DEFAULT_PRIORITY = 10;
 
 	private final String name;
 	private final double energy;


### PR DESCRIPTION
Reordered the DEFAULT_PRIORITY field's modifiers to follow the correct order: private static final instead of private final static.