### PR TITLE
Improving Code Maintainability by Using the Diamond Operator in Generic Type Initialization

### DIFF
--- a/robocode.battle/src/main/java/net/sf/robocode/battle/Battle.java
+++ b/robocode.battle/src/main/java/net/sf/robocode/battle/Battle.java
@@ -431,7 +431,7 @@ public final class Battle extends BaseBattle {
 				}
 			}
 			if (isAborted() || isLastRound()) {
-				List<RobotPeer> orderedRobots = new ArrayList<RobotPeer>(robots);
+				List<RobotPeer> orderedRobots = new ArrayList<>(robots);
 				Collections.sort(orderedRobots);
 				Collections.reverse(orderedRobots);
 


### PR DESCRIPTION
In Java, angular brackets (< and >) are used to define type arguments for generic types, like declaring a list with List<String>. Before Java 7, these type arguments had to be specified explicitly every time generics were used, resulting in redundant code.

Java 7 introduced the diamond operator (<>) to make the code more concise. It allows you to skip the type argument when the compiler can infer it automatically, simplifying the code and reducing verbosity.

However, if the project's Java version (sonar.java.source) is set below 7, this feature is disabled, as the diamond operator is not supported in earlier versions.